### PR TITLE
Fixed OnMouseLeave Woes

### DIFF
--- a/src/components/grid/Grid.js
+++ b/src/components/grid/Grid.js
@@ -7,7 +7,7 @@ import './Grid.css';
 
 export default class Grid extends PureComponent {
   render() {
-    const { grid, selected, nodeExtras, onSelect, onUnselect } = this.props;
+    const { grid, selected, nodeExtras, onSelect, onMouseLeave } = this.props;
 
     if (!grid) {
       return null;
@@ -16,6 +16,7 @@ export default class Grid extends PureComponent {
     return (
       <div
         className='Grid'
+        onMouseLeave={onMouseLeave}
         style={{
           gridTemplateColumns: `repeat(${grid.columns()}, minmax(1em, 2em))`
         }}>
@@ -29,8 +30,7 @@ export default class Grid extends PureComponent {
           <GridSelection
             key={`match${i}`}
             grid={grid}
-            selection={selection}
-            onUnselect={onUnselect} />
+            selection={selection} />
         ) }
       </div>
     );

--- a/src/components/grid/GridSelection.css
+++ b/src/components/grid/GridSelection.css
@@ -1,4 +1,5 @@
 .GridMatches {
-	background: #F57F17;
-	z-index: 1;
+  background: #F57F17;
+  z-index: 1;
+  pointer-events: none;
 }

--- a/src/components/grid/GridSelection.js
+++ b/src/components/grid/GridSelection.js
@@ -4,7 +4,7 @@ import './GridSelection.css';
 // A component which highlights nodes between two points.
 export default class GridSelection extends PureComponent {
   render() {
-    const { selection, grid, onUnselect } = this.props;
+    const { selection, grid } = this.props;
 
     const startNode = selection[0];
     const { x: fromX, y: fromY } = grid.positionOf(startNode);
@@ -17,7 +17,6 @@ export default class GridSelection extends PureComponent {
         <div
           key={`${x},${y}`}
           className='GridMatches'
-          onMouseLeave={() => onUnselect(selection)}
           style={{
             gridColumnStart: x + 1,
             gridRowStart: y + 1,


### PR DESCRIPTION
Forgot to program in the one directional data flow way and was trying to
do things imperatively.

Now, every time a node is moused over, we just reset the selected nodes.
There is no concept of mousing out because we only need to handle the
case of mousing out of the top parent container.

Closes #11